### PR TITLE
fixed warning about resizeMode being copied to style prop for the wrapping View and made staggering delay as an option

### DIFF
--- a/FadeIn.android.js
+++ b/FadeIn.android.js
@@ -1,26 +1,72 @@
 import React from 'react';
-import { StyleSheet, View } from 'react-native';
+import { Animated, StyleSheet, View } from 'react-native';
+import TimerMixin from 'react-timer-mixin';
+
+import reactMixin from 'react-mixin';
+import cloneReferencedElement from 'react-clone-referenced-element';
 
 const onlyChild = React.Children.only;
 
 export default class FadeIn extends React.Component {
+  constructor(props, context) {
+    super(props, context);
+
+    this.state = {
+      placeholderContainerOpacity: new Animated.Value(1),
+    };
+  }
 
   render() {
-    let image = onlyChild(this.props.children);
+    let image = cloneReferencedElement(onlyChild(this.props.children), {
+      ref: component => { this._image = component; },
+      onLoadEnd: this._onLoadEnd,
+    });
+
+    let imageStyle = StyleSheet.flatten(image.props.style);
+
+    // `delete` doesn't work in JSCore? 
+    let imagePortableStyle = {}
+    for (let a in imageStyle) {
+      if (a !== "resizeMode") {
+        imagePortableStyle[a] = imageStyle[a]
+      }
+    };
 
     return (
       <View {...this.props}>
-        <View style={styles.placeholderContainer}>
-          <View style={[image.props.style, styles.placeholder, this.props.placeholderStyle]}>
+        {image}
+
+        <Animated.View style={[styles.placeholderContainer, {opacity: this.state.placeholderContainerOpacity}]}>
+          <View style={[imagePortableStyle, styles.placeholder, this.props.placeholderStyle]}>
             {this.props.renderPlaceholderContent}
           </View>
-        </View>
-
-        {image}
+        </Animated.View>
       </View>
     );
   }
+
+  _onLoadEnd = () => {
+    /* NOTE(brentvatne): If we animate in immediately when the onLoadEvent event
+       fires, there are two unwanted consequences:
+     1. Animation feels janky - not entirely sure why that is
+       (handled with minimumWait)
+     2. [Optional] Many images finish loading in the same frame for some reason, and in my
+       opinion it looks better when the images fade in separately
+       (handled with staggerNonce) */
+
+    const minimumWait = 100;
+    const staggerNonce = this.props.randomDelay ? 200 * Math.random() : 0;
+
+    this.setTimeout(() => {
+      Animated.timing(this.state.placeholderContainerOpacity, {
+        toValue: 0,
+        duration: 350,
+      }).start();
+    }, minimumWait + staggerNonce);
+  };
 }
+
+reactMixin(FadeIn.prototype, TimerMixin);
 
 let styles = StyleSheet.create({
   placeholderContainer: {

--- a/FadeIn.android.js
+++ b/FadeIn.android.js
@@ -24,13 +24,10 @@ export default class FadeIn extends React.Component {
 
     let imageStyle = StyleSheet.flatten(image.props.style);
 
-    // `delete` doesn't work in JSCore? 
-    let imagePortableStyle = {}
-    for (let a in imageStyle) {
-      if (a !== "resizeMode") {
-        imagePortableStyle[a] = imageStyle[a]
-      }
-    };
+    const {
+      resizeMode,
+      ...imagePortableStyle
+    } =  imageStyle
 
     return (
       <View {...this.props}>

--- a/FadeIn.ios.js
+++ b/FadeIn.ios.js
@@ -22,12 +22,22 @@ export default class FadeIn extends React.Component {
       onLoadEnd: this._onLoadEnd,
     });
 
+    let imageStyle = StyleSheet.flatten(image.props.style);
+
+    // `delete` doesn't work in JSCore? 
+    let imagePortableStyle = {}
+    for (let a in imageStyle) {
+      if (a !== "resizeMode") {
+        imagePortableStyle[a] = imageStyle[a]
+      }
+    };
+
     return (
       <View {...this.props}>
         {image}
 
         <Animated.View style={[styles.placeholderContainer, {opacity: this.state.placeholderContainerOpacity}]}>
-          <View style={[image.props.style, styles.placeholder, this.props.placeholderStyle]}>
+          <View style={[imagePortableStyle, styles.placeholder, this.props.placeholderStyle]}>
             {this.props.renderPlaceholderContent}
           </View>
         </Animated.View>
@@ -40,12 +50,12 @@ export default class FadeIn extends React.Component {
        fires, there are two unwanted consequences:
      1. Animation feels janky - not entirely sure why that is
        (handled with minimumWait)
-     2. Many images finish loading in the same frame for some reason, and in my
+     2. [Optional] Many images finish loading in the same frame for some reason, and in my
        opinion it looks better when the images fade in separately
        (handled with staggerNonce) */
 
     const minimumWait = 100;
-    const staggerNonce = 200 * Math.random();
+    const staggerNonce = this.props.randomDelay ? 200 * Math.random() : 0;
 
     this.setTimeout(() => {
       Animated.timing(this.state.placeholderContainerOpacity, {

--- a/FadeIn.ios.js
+++ b/FadeIn.ios.js
@@ -24,13 +24,10 @@ export default class FadeIn extends React.Component {
 
     let imageStyle = StyleSheet.flatten(image.props.style);
 
-    // `delete` doesn't work in JSCore? 
-    let imagePortableStyle = {}
-    for (let a in imageStyle) {
-      if (a !== "resizeMode") {
-        imagePortableStyle[a] = imageStyle[a]
-      }
-    };
+    const {
+      resizeMode,
+      ...imagePortableStyle
+    } =  imageStyle
 
     return (
       <View {...this.props}>

--- a/README.md
+++ b/README.md
@@ -1,11 +1,13 @@
-## @expo/react-native-fade-in-image
+## react-native-fade-in-image-fixed
 
 Wrap Image components in `<FadeIn>` to have them fade in pleasantly when they finish loading.
+
+This is a (hopefully) temporary version of Expo's react-native-fade-in-image by @brentvatne with some fixes and mods
 
 ### Installation
 
 ```
-npm i @expo/react-native-fade-in-image --save
+yarn add react-native-fade-in-image-fixed
 ```
 
 ### Usage
@@ -13,7 +15,7 @@ npm i @expo/react-native-fade-in-image --save
 ```javascript
 import React from 'react';
 import { Image } from 'react-native';
-import FadeIn from '@expo/react-native-fade-in-image';
+import FadeIn from 'react-native-fade-in-image-fixed';
 
 const uri = 'https://d3lwq5rlu14cro.cloudfront.net/v1/AQ5jDS5SYyUkapWWEviV.png';
 
@@ -34,9 +36,3 @@ class FancyImage extends React.Component {
 - `renderPlaceholderContent` renders an element while loading the image, e.g. a spinner.
 - `placeholderStyle` adds style to the placeholder wrapper, default background color is `#eee`.
 
-### Example
-
-See the [example
-project
-source](https://github.com/expo/react-native-fade-in-image/tree/master/example)
-or try it out at https://exp.host/@community/fade-in-image-example

--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Wrap Image components in `<FadeIn>` to have them fade in pleasantly when they finish loading.
 
-This is a (hopefully) temporary version of Expo's react-native-fade-in-image by @brentvatne with some fixes and mods
-
 ### Installation
 
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@expo/react-native-fade-in-image",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Wrap Image components in <FadeIn> to have them fade in pleasantly when they finish loading",
   "main": "index.js",
   "author": "Brent Vatne <brent@getexponent.com>",


### PR DESCRIPTION
fixed warning about resizeMode being copied to style prop for the wrapping View and made staggering delay as an option

@brentvatne not sure what changed in React since you made this but I tried to use it and it works but it shows a yellow warning label (one for View and one for RCTView) that `resizeMode` which I have in my image style should not be mapped to View. I've fixed that.

Given it's been many months since you touched this I assume Android has support now for Animated.View and so I just copied the ios file to android (identical copies) with fingers crossed. If this stuff doesn't work on Android for some reason, I'll be happy to change this PR.
 